### PR TITLE
Optimize deps

### DIFF
--- a/bud.config.mjs
+++ b/bud.config.mjs
@@ -28,6 +28,24 @@ export default async (app) => {
     __VUE_PROD_DEVTOOLS__: false, // If you don't want people sneaking around your components in production.
   });
 
+  app.alias({
+    [`naive-ui$`]: app.isDevelopment
+      ? app.path(`@modules/naive-ui/dist/index.js`) // commonjs modules are faster to build
+      : app.path(`@modules/naive-ui/es/index.js`), // es modules are tree shakeable
+  });
+
+  /**
+   * This is not important for the build optimization
+   * and can be removed if desired.
+   *
+   * The intent is to bundle naive-ui and vue for better transparency
+   * about imports and file sizes of compiled modules.
+   */
+  app
+    .bundle(`vue`, [`vue`])
+    .bundle(`naive-ui`, [`naive-ui, vooks, seemly`])
+    .bundle(`naive-ui-styles`, [`@css-render`, `@emotion`, `@juggle`]);
+
   /**
    * Development server settings
    *

--- a/resources/scripts/app.ts
+++ b/resources/scripts/app.ts
@@ -15,8 +15,3 @@ domReady(async () => {
     },
   });
 });
-
-/**
- * @see {@link https://webpack.org/api/hot-module-replacement/}
- */
-import.meta.webpackHot?.accept(console.error); // eslint-disable-line no-console

--- a/resources/scripts/app.ts
+++ b/resources/scripts/app.ts
@@ -1,17 +1,12 @@
-import domReady from '@roots/sage/client/dom-ready';
 import { createApp } from 'vue';
 import { NMenu } from 'naive-ui';
-/**
- * Application entrypointé
- */
-domReady(async () => {
-  const nav = createApp({
-    components: {
-      'n-menu': NMenu,
-    },
-    setup() {
-      console.log('teuds');
-      const menuItems = [];
-    },
-  });
+
+createApp({
+  components: {
+    'n-menu': NMenu,
+  },
+  setup() {
+    console.log('teuds');
+    const menuItems = [];
+  },
 });


### PR DESCRIPTION
Tree-shaking is fine. Despite the compiler saying `2330 modules` were compiled, most of them are cached. In the next release of bud i've added a cached modules count to make it more transparent; running this repo with that build yields this message: `compiled 2324 modules (2324 cached) in 1s 872ms`. 

But, something with `naive-ui` is weird. You don't see this issue with `buefy` or `bootstrap-vue` (or any of the other vue frontend frameworks I struggled to get working). I think some of this issue might come down to `naive-ui`'s root module doing namespace re-exports of components:

```js
// ...
export * from './locales';
export * from './components';
export * from './composables';
// ...
```

and `components.js` is itself composed entirely of namespace re-exports:

```js
// ...
export * from './breadcrumb';
export * from './button';
export * from './button-group';
export * from './calendar';
// ...
```

My understanding is that this _can_ be challenging for bundlers and optimizers like webpack and terser when they're doing static analysis on used exports and side effects. However, I don't really know 100% what's going on.

Anyway, my solution is to alias `naive-ui` imports to `naive-ui/dist/index.js` in development and `naive-ui/es/index.js` in production. This prevents the transpiler from having to parse thousands of modules in development while also allowing for tree shaking in production.

```js
  app.alias({
    [`naive-ui$`]: app.isDevelopment
      ? app.path(`@modules/naive-ui/dist/index.js`) // commonjs modules are faster to build
      : app.path(`@modules/naive-ui/es/index.js`), // es modules are tree shakeable
  });
```

I tried a lot of other approaches but this approach was simplest and netted the best results.

I also split up the compilation into discrete bundles so that I could check the final output while working to make sure modules were being tree-shaken. The result seems correct to me:

```

╭─ sage ./public [4d56282397aca4c37bc5]
│
├─ entrypoints
│  └─ app
│     ├─ js/runtime.00900e.js                                     1.22 kB
│     ├─ js/bundle/naive-ui-styles/430.688316a1fadc6172b41f.js   10.84 kB
│     ├─ js/bundle/vue/670.a9fb902bd65eeed389c4.js                3.79 kB
│     ├─ js/248.f08eb8.js                                       292.09 kB
│     └─ js/app.c45b99.js                                       399 bytes
│
╰─ compiled 2323 modules (2323 cached) in 1s 862ms
```

Running with the `--no-minimize` flag the header comments all seem to be pointing to relevant modules, and the file sizes seem correct as well.

You can remove the `.bundle` calls if you ultimately don't want this behavior. But, it's not bad to keep it.